### PR TITLE
Don't specify Patch level

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.5.1-wheezy
+FROM golang:1.5
 USER root
 
 # Dependencies


### PR DESCRIPTION
By leaving it out, you make sure that patches are applied automatically (when building)
